### PR TITLE
Resolve RSpec deprecations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,8 @@ ThreadVarAccessor::Logger.initialize_logger(
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,14 @@
 require "bundler"
 Bundler.require :default, :development
 
+Dir[File.expand_path "../support/**/*.rb", __FILE__].sort.each { |f| require f }
+
 # initialize logger
 ThreadVarAccessor::Logger.initialize_logger(
   File.expand_path("../debug.log", __FILE__),
 )
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+end

--- a/spec/thread_var_accessor_spec.rb
+++ b/spec/thread_var_accessor_spec.rb
@@ -20,48 +20,48 @@ describe ThreadVarAccessor do
 
   it "test tva" do
     tc = @test_class
-    tc.test.should be_nil
+    expect(tc.test).to be_nil
     tc.bind_test :foo
     begin
-      tc.test.should eql(:foo)
+      expect(tc.test).to eql(:foo)
       tc.bind_test :bar
       begin
-        tc.test.should eql(:bar)
+        expect(tc.test).to eql(:bar)
         tc.test = nil
-        tc.test.should be_nil
+        expect(tc.test).to be_nil
       ensure
         tc.unbind_test
       end
-      tc.test.should eql(:foo)
+      expect(tc.test).to eql(:foo)
     ensure
       tc.unbind_test
     end
-    tc.test.should be_nil
+    expect(tc.test).to be_nil
   end
 
   it "test binding" do
     tc = @test_class
     tc.binding_test(:foo) do
-      tc.test.should eql(:foo)
+      expect(tc.test).to eql(:foo)
       tc.binding_test(:bar) do
-        tc.test.should eql(:bar)
+        expect(tc.test).to eql(:bar)
         tc.test = nil
-        tc.test.should be_nil
+        expect(tc.test).to be_nil
       end
-      tc.test.should eql(:foo)
+      expect(tc.test).to eql(:foo)
     end
-    tc.test.should be_nil
+    expect(tc.test).to be_nil
   end
 
   it "test independence" do
     tc = @test_class
     tc2 = create_test_class
     tc.binding_test(:foo) do
-      tc.test.should eql(:foo)
-      tc2.test.should be_nil
+      expect(tc.test).to eql(:foo)
+      expect(tc2.test).to be_nil
       tc2.binding_test(:bar) do
-        tc.test.should eql(:foo)
-        tc2.test.should eql(:bar)
+        expect(tc.test).to eql(:foo)
+        expect(tc2.test).to eql(:bar)
       end
     end
   end
@@ -81,16 +81,16 @@ describe ThreadVarAccessor do
     tc.test2 = :initial2
     ti.test3 = :initial3
 
-    [tc.test, tc.test2, ti.test3].should eql(%i[initial initial2 initial3])
+    expect([tc.test, tc.test2, ti.test3]).to eql(%i[initial initial2 initial3])
 
     ThreadVarAccessor.binding_many([tc, :test, :bound1],
                                    [ti, :test3],
                                    [tc, :test2, :bound2]) do
-      tc.test.should eql(:bound1)
-      ti.test3.should be_nil
-      tc.test2.should eql(:bound2)
+      expect(tc.test).to eql(:bound1)
+      expect(ti.test3).to be_nil
+      expect(tc.test2).to eql(:bound2)
     end
 
-    [tc.test, tc.test2, ti.test3].should eql(%i[initial initial2 initial3])
+    expect([tc.test, tc.test2, ti.test3]).to eql(%i[initial initial2 initial3])
   end
 end

--- a/spec/thread_var_accessor_spec.rb
+++ b/spec/thread_var_accessor_spec.rb
@@ -4,7 +4,7 @@
 
 require File.expand_path("../spec_helper", __FILE__)
 
-describe ThreadVarAccessor do
+RSpec.describe ThreadVarAccessor do
   def create_test_class(accessor = :test)
     tc = Class.new
     tc.class_eval do


### PR DESCRIPTION
Update RSpec syntax to the modern one, update configuration, stop monkey-patching.