### PR TITLE
Add Hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
According to Hound documentation, the very default configuration is used unless custom one is specified explicitly.