### PR TITLE
Prepare for Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 sudo: false
 dist: trusty
 language: ruby
-before_install: gem install bundler -v 1.16.0
+
+before_install:
+  - gem install bundler -v 1.17.3
+
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 script:
   - bundle exec rspec

--- a/thread_var_accessor.gemspec
+++ b/thread_var_accessor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "bundler", "~> 1.15"
+  s.add_development_dependency "bundler", ">= 1.15"
   s.add_development_dependency "pry", "~> 0.11"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.7"


### PR DESCRIPTION
Relax Bundler development dependency, so that 2.x is allowed.  However, use the latest 1.x in Travis CI for maximum compatibility with Rubies and gems.  It actually doesn't matter to have 2.x there.